### PR TITLE
Fix App Check token fetching

### DIFF
--- a/flutter/web/index.html
+++ b/flutter/web/index.html
@@ -43,12 +43,15 @@
         token = true;
       }
       try {
-        const response = await fetch('.env');
-        if (response.ok) {
-          const text = await response.text();
-          const match = text.match(/^FIREBASE_APPCHECK_DEBUG_TOKEN=(.*)$/m);
-          if (match && match[1].trim() !== '') {
-            token = match[1].trim();
+        const head = await fetch('.env', { method: 'HEAD' });
+        if (head.ok) {
+          const response = await fetch('.env');
+          if (response.ok) {
+            const text = await response.text();
+            const match = text.match(/^FIREBASE_APPCHECK_DEBUG_TOKEN=(.*)$/m);
+            if (match && match[1].trim() !== '') {
+              token = match[1].trim();
+            }
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Summary
- avoid console errors when `.env` is missing by checking with a HEAD request first

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847f83206608326b1441a290ae19542