### PR TITLE
Fix App Check token fetching

### DIFF
--- a/flutter/web/index.html
+++ b/flutter/web/index.html
@@ -43,12 +43,17 @@
         token = true;
       }
       try {
-        const response = await fetch('.env');
-        if (response.ok) {
-          const text = await response.text();
-          const match = text.match(/^FIREBASE_APPCHECK_DEBUG_TOKEN=(.*)$/m);
-          if (match && match[1].trim() !== '') {
-            token = match[1].trim();
+        if (
+          window.location.hostname === 'localhost' ||
+          window.location.hostname === '127.0.0.1'
+        ) {
+          const response = await fetch('.env');
+          if (response.ok) {
+            const text = await response.text();
+            const match = text.match(/^FIREBASE_APPCHECK_DEBUG_TOKEN=(.*)$/m);
+            if (match && match[1].trim() !== '') {
+              token = match[1].trim();
+            }
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Summary
- avoid 404 errors fetching `.env` by only loading it in local development

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847f83206608326b1441a290ae19542