### PR TITLE
Improve event UI

### DIFF
--- a/flutter/lib/features/create/create_event_screen.dart
+++ b/flutter/lib/features/create/create_event_screen.dart
@@ -106,82 +106,124 @@ class CreateEventScreen extends HookConsumerWidget {
       body: Stack(
         alignment: Alignment.center,
         children: [
-          Column(
-            children: [
-              TextField(
-                controller: eventName,
-                decoration: const InputDecoration(labelText: 'イベント名'),
-              ),
-              Column(
-                children: [
-                  for (final candidateDateTime in candidateDateTimes.value)
-                    Row(
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: eventName,
+                  decoration: const InputDecoration(labelText: 'イベント名'),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text('${candidateDateTime.toLocal()}'),
-                        IconButton(
-                          icon: const Icon(Icons.delete),
-                          onPressed: () =>
-                              deleteCandidateDateTime(candidateDateTime),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text(
+                              '日程候補',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            IconButton(
+                              onPressed: addCandidateDateTime,
+                              icon: const Icon(Icons.add),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
-                ],
-              ),
-              ElevatedButton(
-                onPressed: addCandidateDateTime,
-                child: const Text('日程候補を追加'),
-              ),
-              TextField(
-                controller: budgetUpperLimit,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '予算の上限(円)'),
-              ),
-              TextField(
-                controller: minutes,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '長さ(分)'),
-              ),
-              TextField(
-                controller: allergiesEtc,
-                decoration: const InputDecoration(labelText: 'その他のアレルギー等'),
-              ),
-              // 固定質問の入力セクション
-              Column(
-                children: [
-                  for (var i = 0; i < questionControllers.value.length; i++)
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextField(
-                            controller: questionControllers.value[i],
-                            decoration: InputDecoration(
-                              labelText: '質問 ${i + 1}',
+                        for (final candidateDateTime
+                            in candidateDateTimes.value)
+                          ListTile(
+                            title: Text('${candidateDateTime.toLocal()}'),
+                            trailing: IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () =>
+                                  deleteCandidateDateTime(candidateDateTime),
                             ),
                           ),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.delete),
-                          onPressed: () {
-                            questionControllers.value = List.from(
-                              questionControllers.value,
-                            )..removeAt(i);
-                          },
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: budgetUpperLimit,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '予算の上限(円)'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: minutes,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '長さ(分)'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: allergiesEtc,
+                  decoration: const InputDecoration(labelText: 'その他のアレルギー等'),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      children: [
+                        for (
+                          var i = 0;
+                          i < questionControllers.value.length;
+                          i++
+                        )
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextField(
+                                  controller: questionControllers.value[i],
+                                  decoration: InputDecoration(
+                                    labelText: '質問 ${i + 1}',
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.delete),
+                                onPressed: () {
+                                  questionControllers.value = List.from(
+                                    questionControllers.value,
+                                  )..removeAt(i);
+                                },
+                              ),
+                            ],
+                          ),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton.icon(
+                            onPressed: () {
+                              questionControllers.value = [
+                                ...questionControllers.value,
+                                TextEditingController(),
+                              ];
+                            },
+                            icon: const Icon(Icons.add),
+                            label: const Text('カスタムの質問を追加'),
+                          ),
                         ),
                       ],
                     ),
-                  ElevatedButton(
-                    onPressed: () {
-                      questionControllers.value = [
-                        ...questionControllers.value,
-                        TextEditingController(),
-                      ];
-                    },
-                    child: const Text('カスタムの質問を追加'),
                   ),
-                ],
-              ),
-              ElevatedButton(onPressed: submit, child: const Text('イベントを作成')),
-            ],
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: submit,
+                    child: const Text('イベントを作成'),
+                  ),
+                ),
+              ],
+            ),
           ),
           if (loading.value) ...[
             ModalBarrier(

--- a/flutter/lib/features/vote/vote_screen.dart
+++ b/flutter/lib/features/vote/vote_screen.dart
@@ -63,7 +63,9 @@ class VoteBody extends HookConsumerWidget {
     void addCustomQA() {
       final q = customQuestionController.text;
       final a = customAnswerController.text;
-      if (q.isEmpty || a.isEmpty) return;
+      if (q.isEmpty || a.isEmpty) {
+        return;
+      }
       customQuestions.value = [
         ...customQuestions.value,
         QuestionAnswer(question: q, answer: a),
@@ -106,6 +108,7 @@ class VoteBody extends HookConsumerWidget {
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // 名前
             TextField(
@@ -135,47 +138,64 @@ class VoteBody extends HookConsumerWidget {
             const SizedBox(height: 16),
             // 候補日時から選択
             const Text('日時候補', style: TextStyle(fontWeight: FontWeight.bold)),
-            for (final cd in value.candidateDateTimes)
-              CheckboxListTile(
-                title: Text(
-                  '${cd.start.toLocal()} - ${cd.start.add(Duration(minutes: value.minutes)).toLocal()}',
-                ),
-                value: desiredDates.value.contains(cd.start),
-                onChanged: (selected) {
-                  final list = List<DateTime>.from(desiredDates.value);
-                  if (selected == true) {
-                    list.add(cd.start);
-                  } else {
-                    list.remove(cd.start);
-                  }
-                  desiredDates.value = list;
-                },
+            Card(
+              child: Column(
+                children: [
+                  for (final cd in value.candidateDateTimes)
+                    CheckboxListTile(
+                      title: Text(
+                        '${cd.start.toLocal()} - ${cd.start.add(Duration(minutes: value.minutes)).toLocal()}',
+                      ),
+                      value: desiredDates.value.contains(cd.start),
+                      onChanged: (selected) {
+                        final list = List<DateTime>.from(desiredDates.value);
+                        if (selected == true) {
+                          list.add(cd.start);
+                        } else {
+                          list.remove(cd.start);
+                        }
+                        desiredDates.value = list;
+                      },
+                    ),
+                ],
               ),
+            ),
             const SizedBox(height: 16),
             // 場所候補を文字列で追加
             const Text('場所候補', style: TextStyle(fontWeight: FontWeight.bold)),
-            TextField(
-              decoration: const InputDecoration(labelText: '場所候補を入力'),
-              onSubmitted: (value) {
-                if (value.isNotEmpty) {
-                  desiredLocations.value = List.from(desiredLocations.value)
-                    ..add(value);
-                }
-              },
-            ),
-            for (final location in desiredLocations.value)
-              Row(
-                children: [
-                  Expanded(child: Text(location)),
-                  IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () {
-                      desiredLocations.value = List.from(desiredLocations.value)
-                        ..remove(location);
-                    },
-                  ),
-                ],
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  children: [
+                    TextField(
+                      decoration: const InputDecoration(labelText: '場所候補を入力'),
+                      onSubmitted: (value) {
+                        if (value.isNotEmpty) {
+                          desiredLocations.value = List.from(
+                            desiredLocations.value,
+                          )..add(value);
+                        }
+                      },
+                    ),
+                    for (final location in desiredLocations.value)
+                      Row(
+                        children: [
+                          Expanded(child: Text(location)),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () {
+                              desiredLocations.value = List.from(
+                                desiredLocations.value,
+                              )..remove(location);
+                            },
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
               ),
+            ),
 
             const SizedBox(height: 16),
             // 質問への回答
@@ -189,33 +209,46 @@ class VoteBody extends HookConsumerWidget {
               ),
             const SizedBox(height: 16),
             // カスタム質問追加
-            TextField(
-              controller: customQuestionController,
-              decoration: const InputDecoration(labelText: '追加質問'),
-            ),
-            const SizedBox(height: 8),
-            TextField(
-              controller: customAnswerController,
-              decoration: const InputDecoration(labelText: '回答'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: addCustomQA,
-              child: const Text('カスタム質問を追加'),
-            ),
-            for (final qa in customQuestions.value)
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text('${qa.question}: ${qa.answer}'),
-                  IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () =>
-                        customQuestions.value = List.from(customQuestions.value)
-                          ..remove(qa),
-                  ),
-                ],
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  children: [
+                    TextField(
+                      controller: customQuestionController,
+                      decoration: const InputDecoration(labelText: '追加質問'),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: customAnswerController,
+                      decoration: const InputDecoration(labelText: '回答'),
+                    ),
+                    const SizedBox(height: 8),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton.icon(
+                        onPressed: addCustomQA,
+                        icon: const Icon(Icons.add),
+                        label: const Text('カスタム質問を追加'),
+                      ),
+                    ),
+                    for (final qa in customQuestions.value)
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('${qa.question}: ${qa.answer}'),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () => customQuestions.value = List.from(
+                              customQuestions.value,
+                            )..remove(qa),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
               ),
+            ),
             const SizedBox(height: 16),
             // アレルギー等
             TextField(
@@ -223,7 +256,13 @@ class VoteBody extends HookConsumerWidget {
               decoration: const InputDecoration(labelText: 'アレルギー等'),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(onPressed: submit, child: const Text('投票する')),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: submit,
+                child: const Text('投票する'),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## 変更内容
- イベント作成画面をカード形式で整理し、入力欄のレイアウトを調整
- 投票画面も同様にカードを用いて見やすく整理
- Flutter の解析・フォーマット・ビルドを実行済み

## 確認方法
- `flutter analyze`
- `dart format . --set-exit-if-changed`
- `flutter build web`


------
https://chatgpt.com/codex/tasks/task_e_686171f8c7fc832683da091fc81699b8