### PR TITLE
イベント作成時にGeminiと相談できるように

### DIFF
--- a/flutter/lib/core/firebase/firebase_ai_repo.dart
+++ b/flutter/lib/core/firebase/firebase_ai_repo.dart
@@ -159,3 +159,15 @@ GeminiModelRepo geminiModelRepo(Ref ref) {
   }
   return _GeminiModelRepoImpl(firebaseAI: firebaseAI, model: model);
 }
+
+@riverpod
+ChatSessionRepo geminiChatSession(Ref ref) {
+  final gemini = ref.watch(geminiModelRepoProvider);
+  return gemini.startChat();
+}
+
+@riverpod
+ChatSessionRepo geminiFunctionCallSession(Ref ref, List<Tool> tools) {
+  final gemini = ref.watch(geminiModelRepoProvider);
+  return gemini.startChat(tools: tools);
+}

--- a/flutter/lib/core/firebase/firebase_ai_repo.g.dart
+++ b/flutter/lib/core/firebase/firebase_ai_repo.g.dart
@@ -40,6 +40,169 @@ final geminiModelRepoProvider = AutoDisposeProvider<GeminiModelRepo>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef GeminiModelRepoRef = AutoDisposeProviderRef<GeminiModelRepo>;
+String _$geminiChatSessionHash() => r'648bba245e117797f50d913cd40ad3edc29983f4';
+
+/// See also [geminiChatSession].
+@ProviderFor(geminiChatSession)
+final geminiChatSessionProvider = AutoDisposeProvider<ChatSessionRepo>.internal(
+  geminiChatSession,
+  name: r'geminiChatSessionProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$geminiChatSessionHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GeminiChatSessionRef = AutoDisposeProviderRef<ChatSessionRepo>;
+String _$geminiFunctionCallSessionHash() =>
+    r'0f7b8fb8b17868af104dbae0ffa4b56ac4ded22a';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [geminiFunctionCallSession].
+@ProviderFor(geminiFunctionCallSession)
+const geminiFunctionCallSessionProvider = GeminiFunctionCallSessionFamily();
+
+/// See also [geminiFunctionCallSession].
+class GeminiFunctionCallSessionFamily extends Family<ChatSessionRepo> {
+  /// See also [geminiFunctionCallSession].
+  const GeminiFunctionCallSessionFamily();
+
+  /// See also [geminiFunctionCallSession].
+  GeminiFunctionCallSessionProvider call(List<Tool> tools) {
+    return GeminiFunctionCallSessionProvider(tools);
+  }
+
+  @override
+  GeminiFunctionCallSessionProvider getProviderOverride(
+    covariant GeminiFunctionCallSessionProvider provider,
+  ) {
+    return call(provider.tools);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'geminiFunctionCallSessionProvider';
+}
+
+/// See also [geminiFunctionCallSession].
+class GeminiFunctionCallSessionProvider
+    extends AutoDisposeProvider<ChatSessionRepo> {
+  /// See also [geminiFunctionCallSession].
+  GeminiFunctionCallSessionProvider(List<Tool> tools)
+    : this._internal(
+        (ref) => geminiFunctionCallSession(
+          ref as GeminiFunctionCallSessionRef,
+          tools,
+        ),
+        from: geminiFunctionCallSessionProvider,
+        name: r'geminiFunctionCallSessionProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$geminiFunctionCallSessionHash,
+        dependencies: GeminiFunctionCallSessionFamily._dependencies,
+        allTransitiveDependencies:
+            GeminiFunctionCallSessionFamily._allTransitiveDependencies,
+        tools: tools,
+      );
+
+  GeminiFunctionCallSessionProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.tools,
+  }) : super.internal();
+
+  final List<Tool> tools;
+
+  @override
+  Override overrideWith(
+    ChatSessionRepo Function(GeminiFunctionCallSessionRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: GeminiFunctionCallSessionProvider._internal(
+        (ref) => create(ref as GeminiFunctionCallSessionRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        tools: tools,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<ChatSessionRepo> createElement() {
+    return _GeminiFunctionCallSessionProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GeminiFunctionCallSessionProvider && other.tools == tools;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, tools.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin GeminiFunctionCallSessionRef on AutoDisposeProviderRef<ChatSessionRepo> {
+  /// The parameter `tools` of this provider.
+  List<Tool> get tools;
+}
+
+class _GeminiFunctionCallSessionProviderElement
+    extends AutoDisposeProviderElement<ChatSessionRepo>
+    with GeminiFunctionCallSessionRef {
+  _GeminiFunctionCallSessionProviderElement(super.provider);
+
+  @override
+  List<Tool> get tools => (origin as GeminiFunctionCallSessionProvider).tools;
+}
+
 String _$generativeAIModelHash() => r'43fea863f6be09441a7d725f30411e7f52517fa3';
 
 /// See also [GenerativeAIModel].

--- a/flutter/lib/core/router/root.dart
+++ b/flutter/lib/core/router/root.dart
@@ -8,6 +8,8 @@ import 'package:cheers_planner/features/auth/sign_up_screen.dart';
 import 'package:cheers_planner/features/create/create_event_screen.dart';
 import 'package:cheers_planner/features/create/event_list_screen.dart';
 import 'package:cheers_planner/features/create/management_screen.dart';
+import 'package:cheers_planner/features/create/event_entry.dart';
+import 'package:cheers_planner/features/create/consult_event_screen.dart';
 import 'package:cheers_planner/features/settings/settings_screen.dart';
 import 'package:cheers_planner/features/vote/result_screen.dart';
 import 'package:cheers_planner/features/vote/vote_screen.dart';

--- a/flutter/lib/core/router/root.g.dart
+++ b/flutter/lib/core/router/root.g.dart
@@ -87,6 +87,11 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
               factory: $CreateEventRouteExtension._fromState,
             ),
             GoRouteData.$route(
+              path: 'consult',
+
+              factory: $ConsultEventRouteExtension._fromState,
+            ),
+            GoRouteData.$route(
               path: 'management/:eventId',
 
               factory: $ManagementRouteExtension._fromState,
@@ -154,6 +159,22 @@ extension $CreateEventRouteExtension on CreateEventRoute {
       const CreateEventRoute();
 
   String get location => GoRouteData.$location('/events/create');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $ConsultEventRouteExtension on ConsultEventRoute {
+  static ConsultEventRoute _fromState(GoRouterState state) =>
+      const ConsultEventRoute();
+
+  String get location => GoRouteData.$location('/events/consult');
 
   void go(BuildContext context) => context.go(location);
 

--- a/flutter/lib/core/router/routes/shell_routes/create.dart
+++ b/flutter/lib/core/router/routes/shell_routes/create.dart
@@ -22,6 +22,16 @@ class CreateEventRoute extends GoRouteData {
   }
 }
 
+class ConsultEventRoute extends GoRouteData {
+  const ConsultEventRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    final entry = state.extra! as EventEntry;
+    return ConsultEventScreen(entry: entry);
+  }
+}
+
 class ManagementRoute extends GoRouteData {
   const ManagementRoute(this.eventId);
   final String eventId;

--- a/flutter/lib/core/router/routes/shell_routes/shell_route.dart
+++ b/flutter/lib/core/router/routes/shell_routes/shell_route.dart
@@ -8,6 +8,7 @@ part of '../../root.dart';
           path: '/events',
           routes: <TypedRoute<RouteData>>[
             TypedGoRoute<CreateEventRoute>(path: 'create'),
+            TypedGoRoute<ConsultEventRoute>(path: 'consult'),
             TypedGoRoute<ManagementRoute>(path: 'management/:eventId'),
           ],
         ),

--- a/flutter/lib/features/chat/chat_controller.dart
+++ b/flutter/lib/features/chat/chat_controller.dart
@@ -10,8 +10,8 @@ part 'chat_controller.g.dart';
 class ChatController extends _$ChatController {
   @override
   ChatState build() {
-    final gemini = ref.watch(geminiModelRepoProvider);
-    return ChatState(session: gemini.startChat());
+    final session = ref.watch(geminiChatSessionProvider);
+    return ChatState(session: session);
   }
 
   Future<void> addMessage(String message) async {
@@ -67,7 +67,7 @@ class ChatController extends _$ChatController {
   }
 
   void clearMessages() {
-    final gemini = ref.read(geminiModelRepoProvider);
-    state = ChatState(session: gemini.startChat());
+    final session = ref.read(geminiChatSessionProvider);
+    state = ChatState(session: session);
   }
 }

--- a/flutter/lib/features/chat/chat_controller.g.dart
+++ b/flutter/lib/features/chat/chat_controller.g.dart
@@ -6,7 +6,7 @@ part of 'chat_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatControllerHash() => r'e11cdc784b0640950e0b688d4a6a51ecf908b9dc';
+String _$chatControllerHash() => r'ef645e21628232b6a889ba32dbecab47f3f3fec1';
 
 /// See also [ChatController].
 @ProviderFor(ChatController)

--- a/flutter/lib/features/create/consult_event_controller.dart
+++ b/flutter/lib/features/create/consult_event_controller.dart
@@ -49,11 +49,10 @@ class ConsultEventController extends _$ConsultEventController {
 
   @override
   ConsultEventState build(EventEntry initialEvent) {
-    final gemini = ref.watch(geminiModelRepoProvider);
-    final session = gemini.startChat(
-      tools: [
+    final session = ref.watch(
+      geminiFunctionCallSessionProvider([
         Tool.functionDeclarations([_updateEventTool]),
-      ],
+      ]),
     );
     final chatState = ChatState(session: session);
     return ConsultEventState(chatState: chatState, event: initialEvent);

--- a/flutter/lib/features/create/consult_event_controller.dart
+++ b/flutter/lib/features/create/consult_event_controller.dart
@@ -1,0 +1,159 @@
+import 'package:cheers_planner/core/firebase/firebase_ai_repo.dart';
+import 'package:cheers_planner/features/chat/chat.dart';
+import 'package:cheers_planner/features/chat/chat_exception.dart';
+import 'package:cheers_planner/features/create/event_entry.dart';
+import 'package:firebase_ai/firebase_ai.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'consult_event_controller.freezed.dart';
+part 'consult_event_controller.g.dart';
+
+@freezed
+sealed class ConsultEventState with _$ConsultEventState {
+  const factory ConsultEventState({
+    required ChatState chatState,
+    required EventEntry event,
+    EventEntry? proposed,
+  }) = _ConsultEventState;
+}
+
+@riverpod
+class ConsultEventController extends _$ConsultEventController {
+  static final _updateEventTool = FunctionDeclaration(
+    'updateEvent',
+    'Update the event fields with the provided values.',
+    parameters: {
+      'purpose': Schema.string(description: 'Event name'),
+      'candidateDateTimes': Schema.array(
+        description: 'Candidate start times in ISO8601 format',
+        items: Schema.string(),
+      ),
+      'allergiesEtc': Schema.string(description: 'Additional notes'),
+      'budgetUpperLimit': Schema.integer(description: 'Budget upper limit'),
+      'fixedQuestion': Schema.array(
+        description: 'Questions for all participants',
+        items: Schema.string(),
+      ),
+      'minutes': Schema.integer(description: 'Duration in minutes'),
+    },
+    optionalParameters: [
+      'purpose',
+      'candidateDateTimes',
+      'allergiesEtc',
+      'budgetUpperLimit',
+      'fixedQuestion',
+      'minutes',
+    ],
+  );
+
+  @override
+  ConsultEventState build(EventEntry initialEvent) {
+    final gemini = ref.watch(geminiModelRepoProvider);
+    final session = gemini.startChat(
+      tools: [
+        Tool.functionDeclarations([_updateEventTool]),
+      ],
+    );
+    final chatState = ChatState(session: session);
+    return ConsultEventState(chatState: chatState, event: initialEvent);
+  }
+
+  Future<void> sendMessage(String message) async {
+    var value = state;
+    final chatState = value.chatState;
+    if (chatState.isLoading) {
+      throw ChatAlreadyWaitingForResponseException(message);
+    }
+    var newChatState = chatState.copyWith(
+      isLoading: true,
+      messages: [
+        ...chatState.messages,
+        ChatMessage.completedMessage(
+          role: Role.user,
+          message: message,
+          sentAt: DateTime.now(),
+        ),
+        ChatMessage.receivingMessage(
+          role: Role.model,
+          message: '',
+          sentAt: DateTime.now(),
+        ),
+      ],
+    );
+    state = value.copyWith(chatState: newChatState);
+
+    final responses = newChatState.session.sendMessageStream(
+      Content.text(message),
+    );
+    final buffer = StringBuffer();
+    EventEntry? proposed;
+    await for (final response in responses) {
+      if (response.text != null) {
+        buffer.write(response.text);
+      }
+      if (response.functionCalls.isNotEmpty) {
+        final call = response.functionCalls.first;
+        if (call.name == 'updateEvent') {
+          proposed = _mergeEvent(state.event, call.args);
+        }
+      }
+      newChatState = newChatState.copyWith(
+        messages: [
+          ...newChatState.messages.sublist(0, newChatState.messages.length - 1),
+          ChatMessage.receivingMessage(
+            role: Role.model,
+            message: buffer.isNotEmpty
+                ? buffer.toString()
+                : 'No text message received',
+            sentAt: DateTime.now(),
+          ),
+        ],
+      );
+      state = state.copyWith(chatState: newChatState);
+    }
+
+    newChatState = newChatState.copyWith(
+      isLoading: false,
+      messages: [
+        ...newChatState.messages.sublist(0, newChatState.messages.length - 1),
+        ChatMessage.completedMessage(
+          role: Role.model,
+          message: buffer.toString(),
+          sentAt: DateTime.now(),
+        ),
+      ],
+    );
+    state = state.copyWith(chatState: newChatState, proposed: proposed);
+  }
+
+  void applyProposed() {
+    final proposed = state.proposed;
+    if (proposed != null) {
+      state = state.copyWith(event: proposed, proposed: null);
+    }
+  }
+
+  void clearProposed() {
+    state = state.copyWith(proposed: null);
+  }
+
+  EventEntry _mergeEvent(EventEntry current, Map<String, Object?> args) {
+    return current.copyWith(
+      purpose: (args['purpose'] as String?) ?? current.purpose,
+      candidateDateTimes: args['candidateDateTimes'] != null
+          ? (args['candidateDateTimes'] as List)
+                .whereType<String>()
+                .map((e) => CandidateDateTime(start: DateTime.parse(e)))
+                .toList()
+          : current.candidateDateTimes,
+      allergiesEtc: (args['allergiesEtc'] as String?) ?? current.allergiesEtc,
+      budgetUpperLimit:
+          (args['budgetUpperLimit'] as int?) ?? current.budgetUpperLimit,
+      fixedQuestion: args['fixedQuestion'] != null
+          ? List<String>.from(args['fixedQuestion'] as List)
+          : current.fixedQuestion,
+      minutes: (args['minutes'] as int?) ?? current.minutes,
+    );
+  }
+}

--- a/flutter/lib/features/create/consult_event_controller.freezed.dart
+++ b/flutter/lib/features/create/consult_event_controller.freezed.dart
@@ -1,0 +1,208 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'consult_event_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$ConsultEventState {
+
+ ChatState get chatState; EventEntry get event; EventEntry? get proposed;
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ConsultEventStateCopyWith<ConsultEventState> get copyWith => _$ConsultEventStateCopyWithImpl<ConsultEventState>(this as ConsultEventState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConsultEventState&&(identical(other.chatState, chatState) || other.chatState == chatState)&&(identical(other.event, event) || other.event == event)&&(identical(other.proposed, proposed) || other.proposed == proposed));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,chatState,event,proposed);
+
+@override
+String toString() {
+  return 'ConsultEventState(chatState: $chatState, event: $event, proposed: $proposed)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ConsultEventStateCopyWith<$Res>  {
+  factory $ConsultEventStateCopyWith(ConsultEventState value, $Res Function(ConsultEventState) _then) = _$ConsultEventStateCopyWithImpl;
+@useResult
+$Res call({
+ ChatState chatState, EventEntry event, EventEntry? proposed
+});
+
+
+$ChatStateCopyWith<$Res> get chatState;$EventEntryCopyWith<$Res> get event;$EventEntryCopyWith<$Res>? get proposed;
+
+}
+/// @nodoc
+class _$ConsultEventStateCopyWithImpl<$Res>
+    implements $ConsultEventStateCopyWith<$Res> {
+  _$ConsultEventStateCopyWithImpl(this._self, this._then);
+
+  final ConsultEventState _self;
+  final $Res Function(ConsultEventState) _then;
+
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? chatState = null,Object? event = null,Object? proposed = freezed,}) {
+  return _then(_self.copyWith(
+chatState: null == chatState ? _self.chatState : chatState // ignore: cast_nullable_to_non_nullable
+as ChatState,event: null == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as EventEntry,proposed: freezed == proposed ? _self.proposed : proposed // ignore: cast_nullable_to_non_nullable
+as EventEntry?,
+  ));
+}
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChatStateCopyWith<$Res> get chatState {
+  
+  return $ChatStateCopyWith<$Res>(_self.chatState, (value) {
+    return _then(_self.copyWith(chatState: value));
+  });
+}/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventEntryCopyWith<$Res> get event {
+  
+  return $EventEntryCopyWith<$Res>(_self.event, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventEntryCopyWith<$Res>? get proposed {
+    if (_self.proposed == null) {
+    return null;
+  }
+
+  return $EventEntryCopyWith<$Res>(_self.proposed!, (value) {
+    return _then(_self.copyWith(proposed: value));
+  });
+}
+}
+
+
+/// @nodoc
+
+
+class _ConsultEventState implements ConsultEventState {
+  const _ConsultEventState({required this.chatState, required this.event, this.proposed});
+  
+
+@override final  ChatState chatState;
+@override final  EventEntry event;
+@override final  EventEntry? proposed;
+
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ConsultEventStateCopyWith<_ConsultEventState> get copyWith => __$ConsultEventStateCopyWithImpl<_ConsultEventState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ConsultEventState&&(identical(other.chatState, chatState) || other.chatState == chatState)&&(identical(other.event, event) || other.event == event)&&(identical(other.proposed, proposed) || other.proposed == proposed));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,chatState,event,proposed);
+
+@override
+String toString() {
+  return 'ConsultEventState(chatState: $chatState, event: $event, proposed: $proposed)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ConsultEventStateCopyWith<$Res> implements $ConsultEventStateCopyWith<$Res> {
+  factory _$ConsultEventStateCopyWith(_ConsultEventState value, $Res Function(_ConsultEventState) _then) = __$ConsultEventStateCopyWithImpl;
+@override @useResult
+$Res call({
+ ChatState chatState, EventEntry event, EventEntry? proposed
+});
+
+
+@override $ChatStateCopyWith<$Res> get chatState;@override $EventEntryCopyWith<$Res> get event;@override $EventEntryCopyWith<$Res>? get proposed;
+
+}
+/// @nodoc
+class __$ConsultEventStateCopyWithImpl<$Res>
+    implements _$ConsultEventStateCopyWith<$Res> {
+  __$ConsultEventStateCopyWithImpl(this._self, this._then);
+
+  final _ConsultEventState _self;
+  final $Res Function(_ConsultEventState) _then;
+
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? chatState = null,Object? event = null,Object? proposed = freezed,}) {
+  return _then(_ConsultEventState(
+chatState: null == chatState ? _self.chatState : chatState // ignore: cast_nullable_to_non_nullable
+as ChatState,event: null == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as EventEntry,proposed: freezed == proposed ? _self.proposed : proposed // ignore: cast_nullable_to_non_nullable
+as EventEntry?,
+  ));
+}
+
+/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChatStateCopyWith<$Res> get chatState {
+  
+  return $ChatStateCopyWith<$Res>(_self.chatState, (value) {
+    return _then(_self.copyWith(chatState: value));
+  });
+}/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventEntryCopyWith<$Res> get event {
+  
+  return $EventEntryCopyWith<$Res>(_self.event, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of ConsultEventState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventEntryCopyWith<$Res>? get proposed {
+    if (_self.proposed == null) {
+    return null;
+  }
+
+  return $EventEntryCopyWith<$Res>(_self.proposed!, (value) {
+    return _then(_self.copyWith(proposed: value));
+  });
+}
+}
+
+// dart format on

--- a/flutter/lib/features/create/consult_event_controller.g.dart
+++ b/flutter/lib/features/create/consult_event_controller.g.dart
@@ -7,7 +7,7 @@ part of 'consult_event_controller.dart';
 // **************************************************************************
 
 String _$consultEventControllerHash() =>
-    r'207ab4c7e903aded39d2602bfeeeae1b2b1223e5';
+    r'0f7922f70305cbb5b9ff57e26c8fe6893e4028eb';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/flutter/lib/features/create/consult_event_controller.g.dart
+++ b/flutter/lib/features/create/consult_event_controller.g.dart
@@ -1,0 +1,177 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'consult_event_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$consultEventControllerHash() =>
+    r'207ab4c7e903aded39d2602bfeeeae1b2b1223e5';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$ConsultEventController
+    extends BuildlessAutoDisposeNotifier<ConsultEventState> {
+  late final EventEntry initialEvent;
+
+  ConsultEventState build(EventEntry initialEvent);
+}
+
+/// See also [ConsultEventController].
+@ProviderFor(ConsultEventController)
+const consultEventControllerProvider = ConsultEventControllerFamily();
+
+/// See also [ConsultEventController].
+class ConsultEventControllerFamily extends Family<ConsultEventState> {
+  /// See also [ConsultEventController].
+  const ConsultEventControllerFamily();
+
+  /// See also [ConsultEventController].
+  ConsultEventControllerProvider call(EventEntry initialEvent) {
+    return ConsultEventControllerProvider(initialEvent);
+  }
+
+  @override
+  ConsultEventControllerProvider getProviderOverride(
+    covariant ConsultEventControllerProvider provider,
+  ) {
+    return call(provider.initialEvent);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'consultEventControllerProvider';
+}
+
+/// See also [ConsultEventController].
+class ConsultEventControllerProvider
+    extends
+        AutoDisposeNotifierProviderImpl<
+          ConsultEventController,
+          ConsultEventState
+        > {
+  /// See also [ConsultEventController].
+  ConsultEventControllerProvider(EventEntry initialEvent)
+    : this._internal(
+        () => ConsultEventController()..initialEvent = initialEvent,
+        from: consultEventControllerProvider,
+        name: r'consultEventControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$consultEventControllerHash,
+        dependencies: ConsultEventControllerFamily._dependencies,
+        allTransitiveDependencies:
+            ConsultEventControllerFamily._allTransitiveDependencies,
+        initialEvent: initialEvent,
+      );
+
+  ConsultEventControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.initialEvent,
+  }) : super.internal();
+
+  final EventEntry initialEvent;
+
+  @override
+  ConsultEventState runNotifierBuild(
+    covariant ConsultEventController notifier,
+  ) {
+    return notifier.build(initialEvent);
+  }
+
+  @override
+  Override overrideWith(ConsultEventController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: ConsultEventControllerProvider._internal(
+        () => create()..initialEvent = initialEvent,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        initialEvent: initialEvent,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<ConsultEventController, ConsultEventState>
+  createElement() {
+    return _ConsultEventControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ConsultEventControllerProvider &&
+        other.initialEvent == initialEvent;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, initialEvent.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin ConsultEventControllerRef
+    on AutoDisposeNotifierProviderRef<ConsultEventState> {
+  /// The parameter `initialEvent` of this provider.
+  EventEntry get initialEvent;
+}
+
+class _ConsultEventControllerProviderElement
+    extends
+        AutoDisposeNotifierProviderElement<
+          ConsultEventController,
+          ConsultEventState
+        >
+    with ConsultEventControllerRef {
+  _ConsultEventControllerProviderElement(super.provider);
+
+  @override
+  EventEntry get initialEvent =>
+      (origin as ConsultEventControllerProvider).initialEvent;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/flutter/lib/features/create/consult_event_screen.dart
+++ b/flutter/lib/features/create/consult_event_screen.dart
@@ -1,0 +1,137 @@
+import 'package:cheers_planner/features/create/consult_event_controller.dart';
+import 'package:cheers_planner/features/create/event_entry.dart';
+import 'package:cheers_planner/features/chat/chat.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class ConsultEventScreen extends HookConsumerWidget {
+  const ConsultEventScreen({super.key, required this.entry});
+
+  final EventEntry entry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(consultEventControllerProvider(entry));
+    final notifier = ref.read(consultEventControllerProvider(entry).notifier);
+    final textController = useTextEditingController();
+    final scrollController = useScrollController();
+
+    useEffect(() {
+      if (state.chatState.messages.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (scrollController.hasClients) {
+            scrollController.jumpTo(scrollController.position.maxScrollExtent);
+          }
+        });
+      }
+      return null;
+    }, [state.chatState.messages, scrollController]);
+
+    useEffect(() {
+      final proposed = state.proposed;
+      if (proposed != null) {
+        Future.microtask(() async {
+          final apply = await showDialog<bool>(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('Geminiからの提案'),
+                content: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('イベント名: ${proposed.purpose}'),
+                      Text('予算上限: ${proposed.budgetUpperLimit}'),
+                      Text('長さ: ${proposed.minutes}分'),
+                      Text('その他: ${proposed.allergiesEtc}'),
+                    ],
+                  ),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    child: const Text('反映しない'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    child: const Text('反映する'),
+                  ),
+                ],
+              );
+            },
+          );
+          if (apply == true) {
+            notifier.applyProposed();
+          } else {
+            notifier.clearProposed();
+          }
+        });
+      }
+      return null;
+    }, [state.proposed]);
+
+    void sendMessage() {
+      final text = textController.text.trim();
+      if (text.isNotEmpty) {
+        notifier.sendMessage(text);
+        textController.clear();
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('イベント相談')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('イベント名: ${state.event.purpose}'),
+                Text('予算上限: ${state.event.budgetUpperLimit}'),
+                Text('長さ: ${state.event.minutes}分'),
+                Text('その他: ${state.event.allergiesEtc}'),
+              ],
+            ),
+          ),
+          const Divider(),
+          Expanded(
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: state.chatState.messages.length,
+              itemBuilder: (context, index) {
+                final message = state.chatState.messages[index];
+                return ListTile(
+                  title: Text(message.message),
+                  subtitle: Text(message.role == Role.user ? 'あなた' : 'Gemini'),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: textController,
+                    onSubmitted: (_) => sendMessage(),
+                    decoration: const InputDecoration(
+                      labelText: 'メッセージを入力',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: sendMessage,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/lib/features/create/create_event_screen.dart
+++ b/flutter/lib/features/create/create_event_screen.dart
@@ -3,6 +3,7 @@ import 'package:cheers_planner/core/firebase/auth_exception.dart';
 import 'package:cheers_planner/core/firebase/auth_repo.dart';
 import 'package:cheers_planner/core/router/root.dart';
 import 'package:cheers_planner/features/create/event_entry.dart';
+import 'package:go_router/go_router.dart';
 import 'package:cheers_planner/features/create/event_entry_repo.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
@@ -179,6 +180,29 @@ class CreateEventScreen extends HookConsumerWidget {
                     child: const Text('カスタムの質問を追加'),
                   ),
                 ],
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  final draft = EventEntry(
+                    purpose: eventName.text,
+                    candidateDateTimes: candidateDateTimes.value
+                        .map((e) => CandidateDateTime(start: e))
+                        .toList(),
+                    allergiesEtc: allergiesEtc.text,
+                    organizerId: const [],
+                    budgetUpperLimit: int.tryParse(budgetUpperLimit.text) ?? 0,
+                    fixedQuestion: questionControllers.value
+                        .map((c) => c.text)
+                        .where((t) => t.isNotEmpty)
+                        .toList(),
+                    minutes: int.tryParse(minutes.text) ?? 60,
+                  );
+                  context.push(
+                    const ConsultEventRoute().location,
+                    extra: draft,
+                  );
+                },
+                child: const Text('Geminiと相談'),
               ),
               ElevatedButton(onPressed: submit, child: const Text('イベントを作成')),
             ],


### PR DESCRIPTION
## 変更点
- Gemini の function calling に対応した `ConsultEventController` を追加
- イベント内容をチャットしながら更新できる `ConsultEventScreen` を実装
- ルーティングに `/events/consult` を追加し、作成画面から遷移
- Gemini 用の startChat に tools を渡せるよう FirebaseAI ラッパーを拡張

## 確認方法
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `dart format . --set-exit-if-changed`
- `flutter build web`


------
https://chatgpt.com/codex/tasks/task_e_6861795ad89883268e249b295155d167