### PR TITLE
投票確認画面の追加

### DIFF
--- a/flutter/lib/core/router/root.dart
+++ b/flutter/lib/core/router/root.dart
@@ -12,6 +12,8 @@ import 'package:cheers_planner/features/settings/settings_screen.dart';
 import 'package:cheers_planner/features/vote/result_screen.dart';
 import 'package:cheers_planner/features/vote/vote_screen.dart';
 import 'package:cheers_planner/features/vote/voted_list_screen.dart';
+import 'package:cheers_planner/features/vote/vote_confirm_screen.dart';
+import 'package:cheers_planner/features/vote/participant.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/flutter/lib/core/router/root.g.dart
+++ b/flutter/lib/core/router/root.g.dart
@@ -108,6 +108,11 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
               factory: $VoteRouteExtension._fromState,
             ),
             GoRouteData.$route(
+              path: 'voting/:eventId/confirm',
+
+              factory: $VoteConfirmRouteExtension._fromState,
+            ),
+            GoRouteData.$route(
               path: 'result/:eventId',
 
               factory: $ResultRouteExtension._fromState,
@@ -205,6 +210,24 @@ extension $VoteRouteExtension on VoteRoute {
 
   String get location =>
       GoRouteData.$location('/vote/voting/${Uri.encodeComponent(eventId)}');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $VoteConfirmRouteExtension on VoteConfirmRoute {
+  static VoteConfirmRoute _fromState(GoRouterState state) =>
+      VoteConfirmRoute(state.pathParameters['eventId']!);
+
+  String get location => GoRouteData.$location(
+    '/vote/voting/${Uri.encodeComponent(eventId)}/confirm',
+  );
 
   void go(BuildContext context) => context.go(location);
 

--- a/flutter/lib/core/router/routes/shell_routes/shell_route.dart
+++ b/flutter/lib/core/router/routes/shell_routes/shell_route.dart
@@ -19,6 +19,7 @@ part of '../../root.dart';
           path: '/vote',
           routes: <TypedRoute<RouteData>>[
             TypedGoRoute<VoteRoute>(path: 'voting/:eventId'),
+            TypedGoRoute<VoteConfirmRoute>(path: 'voting/:eventId/confirm'),
             TypedGoRoute<ResultRoute>(path: 'result/:eventId'),
           ],
         ),

--- a/flutter/lib/core/router/routes/shell_routes/vote.dart
+++ b/flutter/lib/core/router/routes/shell_routes/vote.dart
@@ -32,3 +32,14 @@ class ResultRoute extends GoRouteData {
     return ResultScreen(eventId: eventId);
   }
 }
+
+class VoteConfirmRoute extends GoRouteData {
+  const VoteConfirmRoute(this.eventId);
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    final participant = state.extra as EventParticipant;
+    return VoteConfirmScreen(eventId: eventId, participant: participant);
+  }
+}

--- a/flutter/lib/features/vote/vote_confirm_screen.dart
+++ b/flutter/lib/features/vote/vote_confirm_screen.dart
@@ -1,0 +1,87 @@
+import 'package:cheers_planner/core/app/snackbar_repo.dart';
+import 'package:cheers_planner/core/firebase/auth_repo.dart';
+import 'package:cheers_planner/core/router/root.dart';
+import 'package:cheers_planner/features/vote/participant.dart';
+import 'package:cheers_planner/features/vote/participant_repo.dart';
+import 'package:cheers_planner/features/create/event_entry_repo.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class VoteConfirmScreen extends HookConsumerWidget {
+  const VoteConfirmScreen({
+    super.key,
+    required this.eventId,
+    required this.participant,
+  });
+  final String eventId;
+  final EventParticipant participant;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final loading = useState(false);
+
+    Future<void> submit() async {
+      try {
+        loading.value = true;
+        final uid = ref.read(requireUserProvider).uid;
+        await ref.read(participantRepoProvider(eventId)).set(uid, participant);
+        await ref
+            .read(eventEntryRepoProvider(eventId))
+            .addParticipant(eventId, uid);
+        ref.read(snackBarRepoProvider).show('投票が完了しました！');
+        const VotedListRoute().go(context);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('内容確認')),
+      body: Stack(
+        alignment: Alignment.center,
+        children: [
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('名前: ${participant.name}'),
+                Text('電話番号: ${participant.phoneNumber}'),
+                if (participant.positionOrGrade != null)
+                  Text('学年/役職: ${participant.positionOrGrade}'),
+                Text('希望予算: ${participant.desiredBudget}'),
+                const SizedBox(height: 8),
+                const Text('希望日時'),
+                for (final d in participant.desiredDates)
+                  Text(d.toLocal().toString()),
+                const SizedBox(height: 8),
+                const Text('希望場所'),
+                for (final l in participant.desiredLocations) Text(l),
+                const SizedBox(height: 8),
+                const Text('質問への回答'),
+                for (final qa in participant.fixedQuestionAnswers)
+                  Text('${qa.question}: ${qa.answer}'),
+                const SizedBox(height: 8),
+                const Text('追加質問'),
+                for (final qa in participant.customQuestions)
+                  Text('${qa.question}: ${qa.answer}'),
+                const SizedBox(height: 8),
+                Text('アレルギー等: ${participant.allergiesEtc}'),
+                const SizedBox(height: 24),
+                ElevatedButton(onPressed: submit, child: const Text('送信')),
+              ],
+            ),
+          ),
+          if (loading.value) ...[
+            ModalBarrier(
+              dismissible: false,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(150),
+            ),
+            const Center(child: CircularProgressIndicator()),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/lib/features/vote/vote_screen.dart
+++ b/flutter/lib/features/vote/vote_screen.dart
@@ -1,13 +1,11 @@
-import 'package:cheers_planner/core/app/snackbar_repo.dart';
-import 'package:cheers_planner/core/firebase/auth_repo.dart';
 import 'package:cheers_planner/core/router/root.dart';
 import 'package:cheers_planner/features/create/event_entry.dart';
 import 'package:cheers_planner/features/create/event_entry_repo.dart';
 import 'package:cheers_planner/features/vote/participant.dart';
-import 'package:cheers_planner/features/vote/participant_repo.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class VoteScreen extends HookConsumerWidget {
   const VoteScreen({super.key, required this.eventId});
@@ -72,8 +70,8 @@ class VoteBody extends HookConsumerWidget {
       customAnswerController.clear();
     }
 
-    // 投票送信
-    Future<void> submit() async {
+    // 入力内容を確認画面へ
+    void confirmVote() {
       final participant = EventParticipant(
         eventId: value.id,
         name: nameController.text,
@@ -93,13 +91,9 @@ class VoteBody extends HookConsumerWidget {
         customQuestions: customQuestions.value,
         allergiesEtc: allergiesController.text,
       );
-      // 参加者情報を Firestore に保存
-      final eid = value.id!;
-      final uid = ref.read(requireUserProvider).uid;
-      await ref.read(participantRepoProvider(eid)).set(uid, participant);
-      await ref.read(eventEntryRepoProvider(eid)).addParticipant(eid, uid);
-      ref.read(snackBarRepoProvider).show('投票が完了しました！');
-      const VotedListRoute().go(context);
+      GoRouter.of(
+        context,
+      ).push(VoteConfirmRoute(value.id!).location, extra: participant);
     }
 
     return Center(
@@ -223,7 +217,7 @@ class VoteBody extends HookConsumerWidget {
               decoration: const InputDecoration(labelText: 'アレルギー等'),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(onPressed: submit, child: const Text('投票する')),
+            ElevatedButton(onPressed: confirmVote, child: const Text('入力完了')),
           ],
         ),
       ),


### PR DESCRIPTION
## 変更点
- 投票内容確認用`VoteConfirmScreen`を追加
- ルーティングに確認画面へのパスを追加
- 投票画面の送信処理を確認画面へ遷移するよう変更

## 確認方法
- `flutter pub run build_runner build` を実行しコード生成
- `flutter analyze` でエラーがないことを確認
- `flutter build web` が成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_68617698db208326a895998b5585cb30