### PR TITLE
Improve event and vote screens design

### DIFF
--- a/flutter/lib/features/create/create_event_screen.dart
+++ b/flutter/lib/features/create/create_event_screen.dart
@@ -106,82 +106,89 @@ class CreateEventScreen extends HookConsumerWidget {
       body: Stack(
         alignment: Alignment.center,
         children: [
-          Column(
-            children: [
-              TextField(
-                controller: eventName,
-                decoration: const InputDecoration(labelText: 'イベント名'),
-              ),
-              Column(
-                children: [
-                  for (final candidateDateTime in candidateDateTimes.value)
-                    Row(
-                      children: [
-                        Text('${candidateDateTime.toLocal()}'),
-                        IconButton(
-                          icon: const Icon(Icons.delete),
-                          onPressed: () =>
-                              deleteCandidateDateTime(candidateDateTime),
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: eventName,
+                  decoration: const InputDecoration(labelText: 'イベント名'),
+                ),
+                const SizedBox(height: 16),
+                Column(
+                  children: [
+                    for (final candidateDateTime in candidateDateTimes.value)
+                      Card(
+                        child: ListTile(
+                          title: Text('${candidateDateTime.toLocal()}'),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () =>
+                                deleteCandidateDateTime(candidateDateTime),
+                          ),
                         ),
-                      ],
-                    ),
-                ],
-              ),
-              ElevatedButton(
-                onPressed: addCandidateDateTime,
-                child: const Text('日程候補を追加'),
-              ),
-              TextField(
-                controller: budgetUpperLimit,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '予算の上限(円)'),
-              ),
-              TextField(
-                controller: minutes,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '長さ(分)'),
-              ),
-              TextField(
-                controller: allergiesEtc,
-                decoration: const InputDecoration(labelText: 'その他のアレルギー等'),
-              ),
-              // 固定質問の入力セクション
-              Column(
-                children: [
-                  for (var i = 0; i < questionControllers.value.length; i++)
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextField(
+                      ),
+                  ],
+                ),
+                ElevatedButton(
+                  onPressed: addCandidateDateTime,
+                  child: const Text('日程候補を追加'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: budgetUpperLimit,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '予算の上限(円)'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: minutes,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '長さ(分)'),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: allergiesEtc,
+                  decoration: const InputDecoration(labelText: 'その他のアレルギー等'),
+                ),
+                const SizedBox(height: 16),
+                Column(
+                  children: [
+                    for (var i = 0; i < questionControllers.value.length; i++)
+                      Card(
+                        child: ListTile(
+                          title: TextField(
                             controller: questionControllers.value[i],
                             decoration: InputDecoration(
                               labelText: '質問 ${i + 1}',
                             ),
                           ),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () {
+                              questionControllers.value = List.from(
+                                questionControllers.value,
+                              )..removeAt(i);
+                            },
+                          ),
                         ),
-                        IconButton(
-                          icon: const Icon(Icons.delete),
-                          onPressed: () {
-                            questionControllers.value = List.from(
-                              questionControllers.value,
-                            )..removeAt(i);
-                          },
-                        ),
-                      ],
+                      ),
+                    ElevatedButton(
+                      onPressed: () {
+                        questionControllers.value = [
+                          ...questionControllers.value,
+                          TextEditingController(),
+                        ];
+                      },
+                      child: const Text('カスタムの質問を追加'),
                     ),
-                  ElevatedButton(
-                    onPressed: () {
-                      questionControllers.value = [
-                        ...questionControllers.value,
-                        TextEditingController(),
-                      ];
-                    },
-                    child: const Text('カスタムの質問を追加'),
-                  ),
-                ],
-              ),
-              ElevatedButton(onPressed: submit, child: const Text('イベントを作成')),
-            ],
+                  ],
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(onPressed: submit, child: const Text('イベントを作成')),
+              ],
+            ),
           ),
           if (loading.value) ...[
             ModalBarrier(

--- a/flutter/lib/features/vote/vote_screen.dart
+++ b/flutter/lib/features/vote/vote_screen.dart
@@ -63,7 +63,9 @@ class VoteBody extends HookConsumerWidget {
     void addCustomQA() {
       final q = customQuestionController.text;
       final a = customAnswerController.text;
-      if (q.isEmpty || a.isEmpty) return;
+      if (q.isEmpty || a.isEmpty) {
+        return;
+      }
       customQuestions.value = [
         ...customQuestions.value,
         QuestionAnswer(question: q, answer: a),
@@ -106,53 +108,50 @@ class VoteBody extends HookConsumerWidget {
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // 名前
             TextField(
               controller: nameController,
               decoration: const InputDecoration(labelText: '名前'),
             ),
             const SizedBox(height: 8),
-            // 電話番号
             TextField(
               controller: phoneController,
               keyboardType: TextInputType.phone,
               decoration: const InputDecoration(labelText: '電話番号'),
             ),
             const SizedBox(height: 8),
-            // 学年/役職
             TextField(
               controller: positionController,
               decoration: const InputDecoration(labelText: '学年/役職'),
             ),
             const SizedBox(height: 8),
-            // 希望予算
             TextField(
               controller: budgetController,
               keyboardType: TextInputType.number,
               decoration: const InputDecoration(labelText: '希望予算'),
             ),
             const SizedBox(height: 16),
-            // 候補日時から選択
             const Text('日時候補', style: TextStyle(fontWeight: FontWeight.bold)),
             for (final cd in value.candidateDateTimes)
-              CheckboxListTile(
-                title: Text(
-                  '${cd.start.toLocal()} - ${cd.start.add(Duration(minutes: value.minutes)).toLocal()}',
+              Card(
+                child: CheckboxListTile(
+                  title: Text(
+                    '${cd.start.toLocal()} - ${cd.start.add(Duration(minutes: value.minutes)).toLocal()}',
+                  ),
+                  value: desiredDates.value.contains(cd.start),
+                  onChanged: (selected) {
+                    final list = List<DateTime>.from(desiredDates.value);
+                    if (selected == true) {
+                      list.add(cd.start);
+                    } else {
+                      list.remove(cd.start);
+                    }
+                    desiredDates.value = list;
+                  },
                 ),
-                value: desiredDates.value.contains(cd.start),
-                onChanged: (selected) {
-                  final list = List<DateTime>.from(desiredDates.value);
-                  if (selected == true) {
-                    list.add(cd.start);
-                  } else {
-                    list.remove(cd.start);
-                  }
-                  desiredDates.value = list;
-                },
               ),
             const SizedBox(height: 16),
-            // 場所候補を文字列で追加
             const Text('場所候補', style: TextStyle(fontWeight: FontWeight.bold)),
             TextField(
               decoration: const InputDecoration(labelText: '場所候補を入力'),
@@ -163,22 +162,20 @@ class VoteBody extends HookConsumerWidget {
                 }
               },
             ),
-            for (final location in desiredLocations.value)
-              Row(
-                children: [
-                  Expanded(child: Text(location)),
-                  IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () {
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final location in desiredLocations.value)
+                  Chip(
+                    label: Text(location),
+                    onDeleted: () {
                       desiredLocations.value = List.from(desiredLocations.value)
                         ..remove(location);
                     },
                   ),
-                ],
-              ),
-
+              ],
+            ),
             const SizedBox(height: 16),
-            // 質問への回答
             for (final q in value.fixedQuestion)
               Padding(
                 padding: const EdgeInsets.only(bottom: 8),
@@ -188,7 +185,6 @@ class VoteBody extends HookConsumerWidget {
                 ),
               ),
             const SizedBox(height: 16),
-            // カスタム質問追加
             TextField(
               controller: customQuestionController,
               decoration: const InputDecoration(labelText: '追加質問'),
@@ -204,20 +200,18 @@ class VoteBody extends HookConsumerWidget {
               child: const Text('カスタム質問を追加'),
             ),
             for (final qa in customQuestions.value)
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text('${qa.question}: ${qa.answer}'),
-                  IconButton(
+              Card(
+                child: ListTile(
+                  title: Text('${qa.question}: ${qa.answer}'),
+                  trailing: IconButton(
                     icon: const Icon(Icons.delete),
                     onPressed: () =>
                         customQuestions.value = List.from(customQuestions.value)
                           ..remove(qa),
                   ),
-                ],
+                ),
               ),
             const SizedBox(height: 16),
-            // アレルギー等
             TextField(
               controller: allergiesController,
               decoration: const InputDecoration(labelText: 'アレルギー等'),


### PR DESCRIPTION
## 変更点
- イベント作成画面をスクロール可能なレイアウトに変更し、各入力欄をCardで装飾
- 投票画面も同様にCardやChipを使用してスタイリング

## 確認方法
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `dart format . --set-exit-if-changed`
- `flutter build web`
以上が通ることを確認してください。

------
https://chatgpt.com/codex/tasks/task_e_686171f8c7fc832683da091fc81699b8