### PR TITLE
イベント削除機能の追加

### DIFF
--- a/flutter/lib/features/create/event_list_screen.dart
+++ b/flutter/lib/features/create/event_list_screen.dart
@@ -21,6 +21,31 @@ class EventListScreen extends HookConsumerWidget {
           return ListTile(
             title: Text(event.purpose),
             onTap: () => ManagementRoute(event.id!).go(context),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () async {
+                final shouldDelete = await showDialog<bool>(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: const Text('イベントを削除'),
+                    content: const Text('このイベントを削除しますか？'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, false),
+                        child: const Text('キャンセル'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, true),
+                        child: const Text('削除'),
+                      ),
+                    ],
+                  ),
+                );
+                if (shouldDelete ?? false) {
+                  await ref.read(eventEntryRepoProvider(event.id!)).delete();
+                }
+              },
+            ),
           );
         },
         emptyBuilder: (context) =>

--- a/flutter/lib/features/create/management_screen.dart
+++ b/flutter/lib/features/create/management_screen.dart
@@ -67,6 +67,33 @@ class ManagementBody extends HookConsumerWidget {
             },
             child: const Text('レコメンドを生成'),
           ),
+          ElevatedButton(
+            onPressed: () async {
+              final shouldDelete = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('イベントを削除'),
+                  content: const Text('このイベントを削除しますか？'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, false),
+                      child: const Text('キャンセル'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, true),
+                      child: const Text('削除'),
+                    ),
+                  ],
+                ),
+              );
+              if (shouldDelete ?? false) {
+                await ref.read(eventEntryRepoProvider(value.id!)).delete();
+                ref.read(snackBarRepoProvider).show('イベントを削除しました');
+                const EventListRoute().go(context);
+              }
+            },
+            child: const Text('イベントを削除'),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## 変更点
- イベント一覧の各アイテムに削除ボタンを追加
- 管理画面からイベントを削除できるように変更

## 確認方法
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `dart format . --set-exit-if-changed`
- `flutter build web`


------
https://chatgpt.com/codex/tasks/task_e_6861dbfc5eac8326914d2c6db94997ff