### PR TITLE
Add delete vote feature

### DIFF
--- a/flutter/lib/features/create/event_entry_repo.dart
+++ b/flutter/lib/features/create/event_entry_repo.dart
@@ -74,6 +74,12 @@ class EventEntryRepo {
     });
   }
 
+  Future<void> removeParticipant(String eventId, String participantId) {
+    return _doc.update({
+      'participantId': FieldValue.arrayRemove([participantId]),
+    });
+  }
+
   Future<void> delete() => _doc.delete();
 }
 

--- a/flutter/lib/features/vote/vote_screen.dart
+++ b/flutter/lib/features/vote/vote_screen.dart
@@ -63,7 +63,9 @@ class VoteBody extends HookConsumerWidget {
     void addCustomQA() {
       final q = customQuestionController.text;
       final a = customAnswerController.text;
-      if (q.isEmpty || a.isEmpty) return;
+      if (q.isEmpty || a.isEmpty) {
+        return;
+      }
       customQuestions.value = [
         ...customQuestions.value,
         QuestionAnswer(question: q, answer: a),

--- a/flutter/lib/features/vote/voted_list_screen.dart
+++ b/flutter/lib/features/vote/voted_list_screen.dart
@@ -1,6 +1,8 @@
+import 'package:cheers_planner/core/app/snackbar_repo.dart';
 import 'package:cheers_planner/core/firebase/auth_repo.dart';
 import 'package:cheers_planner/core/router/root.dart';
 import 'package:cheers_planner/features/create/event_entry_repo.dart';
+import 'package:cheers_planner/features/vote/participant_repo.dart';
 import 'package:firebase_ui_firestore/firebase_ui_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -18,9 +20,42 @@ class VotedListScreen extends HookConsumerWidget {
         query: eventEntriesRepo.votedEventListQuery(uid),
         itemBuilder: (context, snapshot) {
           final event = snapshot.data();
+          Future<void> deleteVote() async {
+            final confirm = await showDialog<bool>(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('削除確認'),
+                content: const Text('投票を削除しますか？'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    child: const Text('キャンセル'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    child: const Text('削除'),
+                  ),
+                ],
+              ),
+            );
+            if (confirm != true) {
+              return;
+            }
+            final id = event.id!;
+            await ref.read(participantRepoProvider(id)).delete(uid);
+            await ref
+                .read(eventEntryRepoProvider(id))
+                .removeParticipant(id, uid);
+            ref.read(snackBarRepoProvider).show('投票を削除しました');
+          }
+
           return ListTile(
             title: Text(event.purpose),
             onTap: () => ResultRoute(event.id!).go(context),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: deleteVote,
+            ),
           );
         },
         emptyBuilder: (context) =>


### PR DESCRIPTION
## 変更点
- EventEntryRepo に参加者削除処理を追加
- 投票画面の入力バリデーション修正
- 投票一覧から投票削除できる UI を追加

## 確認方法
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `dart format . --set-exit-if-changed`
- `flutter build web`


------
https://chatgpt.com/codex/tasks/task_e_6861dc09ba588326b6aaa841d8c46249